### PR TITLE
ar71xx: disable 40Mhz refclk for QCA953x

### DIFF
--- a/target/linux/ar71xx/patches-4.4/620-MIPS-ath79-add-support-for-QCA953x-SoC.patch
+++ b/target/linux/ar71xx/patches-4.4/620-MIPS-ath79-add-support-for-QCA953x-SoC.patch
@@ -44,7 +44,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  config ATH79_NVRAM
 --- a/arch/mips/ath79/clock.c
 +++ b/arch/mips/ath79/clock.c
-@@ -354,6 +354,91 @@ static void __init ar934x_clocks_init(vo
+@@ -354,6 +354,87 @@ static void __init ar934x_clocks_init(vo
  	iounmap(dpll_base);
  }
  
@@ -56,13 +56,9 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +	unsigned long ahb_rate;
 +	u32 pll, out_div, ref_div, nint, frac, clk_ctrl, postdiv;
 +	u32 cpu_pll, ddr_pll;
-+	u32 bootstrap;
 +
-+	bootstrap = ath79_reset_rr(QCA953X_RESET_REG_BOOTSTRAP);
-+	if (bootstrap &	QCA953X_BOOTSTRAP_REF_CLK_40)
-+		ref_rate = 40 * 1000 * 1000;
-+	else
-+		ref_rate = 25 * 1000 * 1000;
++	/* QCA953X only supports 25MHz ref_clk */
++	ref_rate = 25 * 1000 * 1000;
 +
 +	pll = ath79_pll_rr(QCA953X_PLL_CPU_CONFIG_REG);
 +	out_div = (pll >> QCA953X_PLL_CPU_CONFIG_OUTDIV_SHIFT) &
@@ -136,7 +132,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  static void __init qca955x_clocks_init(void)
  {
  	unsigned long ref_rate;
-@@ -451,6 +536,8 @@ void __init ath79_clocks_init(void)
+@@ -451,6 +532,8 @@ void __init ath79_clocks_init(void)
  		ar933x_clocks_init();
  	else if (soc_is_ar934x())
  		ar934x_clocks_init();
@@ -247,14 +243,12 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  
  	ath79_wmac_data.external_reset = ar933x_wmac_reset;
  }
-@@ -150,6 +150,26 @@ static void ar934x_wmac_setup(void)
+@@ -150,6 +150,21 @@ static void ar934x_wmac_setup(void)
  	ath79_wmac_data.get_mac_revision = ar93xx_get_soc_revision;
  }
  
 +static void qca953x_wmac_setup(void)
 +{
-+	u32 t;
-+
 +	ath79_wmac_device.name = "qca953x_wmac";
 +
 +	ath79_wmac_resources[0].start = QCA953X_WMAC_BASE;
@@ -262,11 +256,8 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +	ath79_wmac_resources[1].start = ATH79_IP2_IRQ(1);
 +	ath79_wmac_resources[1].end = ATH79_IP2_IRQ(1);
 +
-+	t = ath79_reset_rr(QCA953X_RESET_REG_BOOTSTRAP);
-+	if (t & QCA953X_BOOTSTRAP_REF_CLK_40)
-+		ath79_wmac_data.is_clk_25mhz = false;
-+	else
-+		ath79_wmac_data.is_clk_25mhz = true;
++	/* QCA953X only supports 25MHz ref_clk */
++	ath79_wmac_data.is_clk_25mhz = true;
 +
 +	ath79_wmac_data.get_mac_revision = ar93xx_get_soc_revision;
 +}
@@ -274,7 +265,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  static void qca955x_wmac_setup(void)
  {
  	u32 t;
-@@ -379,6 +399,8 @@ void __init ath79_register_wmac(u8 *cal_
+@@ -379,6 +394,8 @@ void __init ath79_register_wmac(u8 *cal_
  		ar933x_wmac_setup();
  	else if (soc_is_ar934x())
  		ar934x_wmac_setup();
@@ -550,7 +541,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +#define QCA953X_BOOTSTRAP_SW_OPTION2	BIT(12)
 +#define QCA953X_BOOTSTRAP_SW_OPTION1	BIT(11)
 +#define QCA953X_BOOTSTRAP_EJTAG_MODE	BIT(5)
-+#define QCA953X_BOOTSTRAP_REF_CLK_40	BIT(4)
++#define QCA953X_BOOTSTRAP_REF_CLK	BIT(4)
 +#define QCA953X_BOOTSTRAP_SDRAM_DISABLED BIT(1)
 +#define QCA953X_BOOTSTRAP_DDR1		BIT(0)
 +

--- a/target/linux/ar71xx/patches-4.9/620-MIPS-ath79-add-support-for-QCA953x-SoC.patch
+++ b/target/linux/ar71xx/patches-4.9/620-MIPS-ath79-add-support-for-QCA953x-SoC.patch
@@ -44,7 +44,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  config ATH79_NVRAM
 --- a/arch/mips/ath79/clock.c
 +++ b/arch/mips/ath79/clock.c
-@@ -358,6 +358,91 @@ static void __init ar934x_clocks_init(vo
+@@ -358,6 +358,87 @@ static void __init ar934x_clocks_init(vo
  	iounmap(dpll_base);
  }
  
@@ -56,13 +56,9 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +	unsigned long ahb_rate;
 +	u32 pll, out_div, ref_div, nint, frac, clk_ctrl, postdiv;
 +	u32 cpu_pll, ddr_pll;
-+	u32 bootstrap;
 +
-+	bootstrap = ath79_reset_rr(QCA953X_RESET_REG_BOOTSTRAP);
-+	if (bootstrap &	QCA953X_BOOTSTRAP_REF_CLK_40)
-+		ref_rate = 40 * 1000 * 1000;
-+	else
-+		ref_rate = 25 * 1000 * 1000;
++	/* QCA953X only supports 25MHz ref_clk */
++	ref_rate = 25 * 1000 * 1000;
 +
 +	pll = ath79_pll_rr(QCA953X_PLL_CPU_CONFIG_REG);
 +	out_div = (pll >> QCA953X_PLL_CPU_CONFIG_OUTDIV_SHIFT) &
@@ -136,7 +132,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  static void __init qca955x_clocks_init(void)
  {
  	unsigned long ref_rate;
-@@ -453,6 +538,8 @@ void __init ath79_clocks_init(void)
+@@ -453,6 +534,8 @@ void __init ath79_clocks_init(void)
  		ar933x_clocks_init();
  	else if (soc_is_ar934x())
  		ar934x_clocks_init();
@@ -247,14 +243,12 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  
  	ath79_wmac_data.external_reset = ar933x_wmac_reset;
  }
-@@ -150,6 +150,26 @@ static void ar934x_wmac_setup(void)
+@@ -150,6 +150,21 @@ static void ar934x_wmac_setup(void)
  	ath79_wmac_data.get_mac_revision = ar93xx_get_soc_revision;
  }
  
 +static void qca953x_wmac_setup(void)
 +{
-+	u32 t;
-+
 +	ath79_wmac_device.name = "qca953x_wmac";
 +
 +	ath79_wmac_resources[0].start = QCA953X_WMAC_BASE;
@@ -262,11 +256,8 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +	ath79_wmac_resources[1].start = ATH79_IP2_IRQ(1);
 +	ath79_wmac_resources[1].end = ATH79_IP2_IRQ(1);
 +
-+	t = ath79_reset_rr(QCA953X_RESET_REG_BOOTSTRAP);
-+	if (t & QCA953X_BOOTSTRAP_REF_CLK_40)
-+		ath79_wmac_data.is_clk_25mhz = false;
-+	else
-+		ath79_wmac_data.is_clk_25mhz = true;
++	/* QCA953X only supports 25MHz ref_clk */
++	ath79_wmac_data.is_clk_25mhz = true;
 +
 +	ath79_wmac_data.get_mac_revision = ar93xx_get_soc_revision;
 +}
@@ -274,7 +265,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
  static void qca955x_wmac_setup(void)
  {
  	u32 t;
-@@ -379,6 +399,8 @@ void __init ath79_register_wmac(u8 *cal_
+@@ -379,6 +394,8 @@ void __init ath79_register_wmac(u8 *cal_
  		ar933x_wmac_setup();
  	else if (soc_is_ar934x())
  		ar934x_wmac_setup();
@@ -550,7 +541,7 @@ meaning of the bits CPUCLK_FROM_CPUPLL and DDRCLK_FROM_DDRPLL is reversed.
 +#define QCA953X_BOOTSTRAP_SW_OPTION2	BIT(12)
 +#define QCA953X_BOOTSTRAP_SW_OPTION1	BIT(11)
 +#define QCA953X_BOOTSTRAP_EJTAG_MODE	BIT(5)
-+#define QCA953X_BOOTSTRAP_REF_CLK_40	BIT(4)
++#define QCA953X_BOOTSTRAP_REF_CLK	BIT(4)
 +#define QCA953X_BOOTSTRAP_SDRAM_DISABLED BIT(1)
 +#define QCA953X_BOOTSTRAP_DDR1		BIT(0)
 +


### PR DESCRIPTION
The "QCA9531 v2.0 802.11n 2x2 2.4 GHz Premium SOC for WLAN Platforms" datasheet (80-Y7991-1 Rev. C - October 2014) doesn't specify support for a 40 Mhz reference clock. The register description for "Bootstrap Options" (page 31) defines following states for the bit 4 (REF_CLK):

* 0 - CLK25 (default)
* 1 - (reserved)

Devices like the TP-Link CPE210 v2 has this bit set to 1 but is using a 25 Mhz reference clock. OpenWrt is still interpreted this bit as 40 Mhz and then break the bootup of the system due to this incorrect interpretation.

@pepe2k showed a screenshot of the datasheet in https://github.com/openwrt/openwrt/pull/642#pullrequestreview-90073248

This change is a dependency of PR #642. @robimarko, please drop the other patches from your PR when this one is accepted.

This change was tested with success on an OpenMesh OM2Pv4 and a TP-Link CPE210 v2

@neoraider, you've added the first version of the QCA953x support to OpenWrt in f80f0c7d221d ("ar71xx: add support for QCA953x SoC"). Maybe you also have some input regarding this problem.