### PR TITLE
Fix LAN/WAN LEDs

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/iface/11-eth-init
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/iface/11-eth-init
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case $board in
+        netgear,wac510)
+                if [ $ACTION = ifup ]; then
+			# Toggle eth LED pin to activate eth[0,1] LEDs when the interface comes up
+                        echo 0 > /sys/class/leds/wac510\:green\:eth/brightness
+                        echo 1 > /sys/class/leds/wac510\:green\:eth/brightness
+                fi
+                ;;
+esac
+;;
+


### PR DESCRIPTION
eth[0,1] LEDs do not work at bootup until the eth port is disabled/enabled.

By toggling the LED on GPIO62, this restarts the eth port and both eth[0,1] LEDs
then work as expected.