### PR TITLE
Fix wifi mac addresses in WAC510

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -20,6 +20,9 @@ case "$board" in
 	netgear,r7800)
 		echo $(macaddr_add $(mtd_get_mac_binary art 6)  $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+  	netgear,wac510)
+    		echo $(macaddr_add $(mtd_get_mac_binary 0:ART 0)  $(($PHYNBR + 1)) ) > /sys${DEVPATH}/macaddress
+    		;;
 	tplink,c2600)
 		echo $(macaddr_add $(mtd_get_mac_binary default-mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;


### PR DESCRIPTION
Properly set the wifi MAC addresses in WAC510. Changes only take effect after a network restart via init.d script