### PR TITLE
ipq807x: QNAP 301w minor dts changes

### DIFF
--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -134,25 +134,25 @@
    
 		led_10g_1_green: 10g_1-green {
 			label = "green:10g_1";
-			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
 		};
 
 		led_10g_1_amber: 10g_1-amber {
 			label = "amber:10g_1";
-			gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
 		};
 
 		led_10g_2_green: 10g_2-green {
 			label = "green:10g_2";
-			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
 		};
 
 		led_10g_2_amber: 10g_2-amber {
 			label = "amber:10g_2";
-			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
 		};
 	};
@@ -265,25 +265,25 @@
 			bias-pull-down;
 		}; 
 		led_10g_1_green {
-			pins = "gpio51";
-			function = "gpio";
-			drive-strength = <8>;
-			bias-pull-down;
-		};
-		led_10g_1_amber {
-			pins = "gpio52";
-			function = "gpio";
-			drive-strength = <8>;
-			bias-pull-down;
-		}; 
-		led_10g_2_green {
 			pins = "gpio54";
 			function = "gpio";
 			drive-strength = <8>;
 			bias-pull-down;
 		};
-		led_10g_2_amber {
+		led_10g_1_amber {
 			pins = "gpio56";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		}; 
+		led_10g_2_green {
+			pins = "gpio51";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+		led_10g_2_amber {
+			pins = "gpio52";
 			function = "gpio";
 			drive-strength = <8>;
 			bias-pull-down;


### PR DESCRIPTION
1. Led alias/node for led 10g_1 and 10g_2 doesn't match the silkscreen on the case. Fixing that by swapping the gpio's.
2. Remove the reset-gpio's from the ethernet-phy@0 & ethernet-phy@8 node. They aren't needed.
    
Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>